### PR TITLE
SERVER-18236 refactor secondaryOk and readPreference

### DIFF
--- a/src/mongo/client/read_preference.h
+++ b/src/mongo/client/read_preference.h
@@ -136,8 +136,8 @@ namespace mongo {
          */
         static StatusWith<ReadPreferenceSetting> fromBSON(const BSONObj& readPrefSettingObj);
 
-        const ReadPreference pref{ReadPreference::PrimaryOnly};
-        const TagSet tags{TagSet::primaryOnly()};
+        ReadPreference pref{ReadPreference::PrimaryOnly};
+        TagSet tags{TagSet::primaryOnly()};
     };
 
 } // namespace mongo

--- a/src/mongo/db/commands.h
+++ b/src/mongo/db/commands.h
@@ -278,12 +278,9 @@ namespace mutablebson {
          * functionality relevant to a specific command should be confined to its run() method.
          *
          * This is currently used by mongod and dbwebserver.
-         *
-         * TODO: Remove interposedCmd, see SERVER-18236
          */
         static void execCommand(OperationContext* txn,
                                 Command* command,
-                                const BSONObj& interposedCmd,
                                 const rpc::RequestInterface& request,
                                 rpc::ReplyBuilderInterface* replyBuilder);
 

--- a/src/mongo/db/dbwebserver.cpp
+++ b/src/mongo/db/dbwebserver.cpp
@@ -266,8 +266,7 @@ namespace {
             rpc::CommandRequest cmdRequest{cmdRequestMsg.get()};
             rpc::CommandReplyBuilder cmdReplyBuilder{};
 
-            // TODO: remove cmdObj from parameters (SERVER-18236)
-            Command::execCommand(txn, c, cmdObj, cmdRequest, &cmdReplyBuilder);
+            Command::execCommand(txn, c, cmdRequest, &cmdReplyBuilder);
 
             auto cmdReplyMsg = cmdReplyBuilder.done();
             rpc::CommandReply cmdReply{cmdReplyMsg.get()};

--- a/src/mongo/db/instance.cpp
+++ b/src/mongo/db/instance.cpp
@@ -1130,7 +1130,6 @@ namespace {
                 rpc::LegacyReplyBuilder cmdReplyBuilder{};
                 Command::execCommand(txn,
                                      createIndexesCmd,
-                                     cmdObj, // TODO remove (SERVER-18236)
                                      cmdRequest,
                                      &cmdReplyBuilder);
                 auto cmdReplyMsg = cmdReplyBuilder.done();

--- a/src/mongo/rpc/SConscript
+++ b/src/mongo/rpc/SConscript
@@ -113,7 +113,24 @@ env.Library(
         'metadata',
     ],
     source=[
-        'metadata.cpp'
+        'metadata.cpp',
+        'metadata/server_selectors.cpp',
+    ],
+    LIBDEPS=[
+        '$BUILD_DIR/mongo/client/read_preference',
+        '$BUILD_DIR/mongo/util/decorable',
+    ],
+)
+
+env.CppUnitTest(
+    target=[
+        'metadata_test',
+    ],
+    source=[
+        'metadata/server_selectors_test.cpp',
+    ],
+    LIBDEPS=[
+        'metadata',
     ],
 )
 

--- a/src/mongo/rpc/metadata.h
+++ b/src/mongo/rpc/metadata.h
@@ -34,6 +34,8 @@
 
 namespace mongo {
     class BSONObj;
+    class BSONObjBuilder;
+    class OperationContext;
 
 /**
  * Utilities for converting metadata between the legacy OP_QUERY format and the new
@@ -55,15 +57,22 @@ namespace mongo {
 namespace rpc {
 namespace metadata {
 
+    // TODO refactor this stuff to metadata folder.
+
     /**
      * Returns an empty metadata object.
      */
     BSONObj empty();
 
     /**
-     * The field name for the secondaryOk metadata field.
+     * Read metadata from a metadata object and set it on this OperationContext.
      */
-    extern const char kSecondaryOk[];
+    Status read(OperationContext* txn, const BSONObj& metadataObj);
+
+    /**
+     * Write metadata from an OperationContext to a metadata object.
+     */
+    Status write(OperationContext* txn, BSONObjBuilder* metadataBob);
 
     /**
      * A command object and a corresponding metadata object.

--- a/src/mongo/rpc/metadata/server_selectors.cpp
+++ b/src/mongo/rpc/metadata/server_selectors.cpp
@@ -1,0 +1,274 @@
+/*
+ *    Copyright (C) 2015 MongoDB Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *    As a special exception, the copyright holders give permission to link the
+ *    code of portions of this program with the OpenSSL library under certain
+ *    conditions as described in each individual source file and distribute
+ *    linked combinations including the program with the OpenSSL library. You
+ *    must comply with the GNU Affero General Public License in all respects for
+ *    all of the code used other than as permitted herein. If you modify file(s)
+ *    with this exception, you may extend this exception to your version of the
+ *    file(s), but you are not obligated to do so. If you do not wish to do so,
+ *    delete this exception statement from your version. If you delete this
+ *    exception statement from all source files in the program, then also delete
+ *    it in the license file.
+ */
+
+#include "mongo/platform/basic.h"
+
+#include "mongo/rpc/metadata/server_selectors.h"
+
+#include <utility>
+#include <tuple>
+
+#include "mongo/base/status_with.h"
+#include "mongo/bson/util/bson_extract.h"
+#include "mongo/client/dbclientinterface.h"
+#include "mongo/db/jsobj.h"
+#include "mongo/db/operation_context.h"
+#include "mongo/util/assert_util.h"
+
+namespace mongo {
+namespace rpc {
+namespace metadata {
+
+namespace {
+
+    const char kSecondaryOkFieldName[] = "$secondaryOk";
+    const char kReadPreferenceFieldName[] = "$readPreference";
+
+    const char kQueryOptionsFieldName[] = "$queryOptions";
+
+    const char kDollarQueryWrapper[] = "$query";
+    const char kQueryWrapper[] = "query";
+
+    /**
+     * Utility to unwrap a '$query' or 'query' wrapped command object. The first element of the
+     * return value indicates whether the command was unwrapped, and the second element is either
+     * the unwrapped command (if it was wrapped), or the original command if it was not.
+     */
+    std::tuple<bool, BSONObj> unwrapCommand(const BSONObj& maybeWrapped) {
+        const auto firstElFieldName = maybeWrapped.firstElementFieldName();
+        if ((firstElFieldName == StringData(kDollarQueryWrapper)) ||
+            (firstElFieldName == StringData(kQueryWrapper))) {
+            // TODO: do we need getOwned here?
+            return std::make_tuple(true, maybeWrapped.firstElement().embeddedObject().getOwned());
+        }
+        return std::make_tuple(false, maybeWrapped);
+    }
+
+    /**
+     * Reads a top-level $readPreference field from a wrapped command.
+     */
+    Status extractWrappedReadPreference(const BSONObj& wrappedCommand,
+                                        BSONObjBuilder* metadataBob) {
+        BSONElement readPrefEl;
+        auto rpExtractStatus = bsonExtractTypedField(wrappedCommand,
+                                                     kReadPreferenceFieldName,
+                                                     mongo::Object,
+                                                     &readPrefEl);
+        if (rpExtractStatus.isOK()) {
+            metadataBob->append(readPrefEl);
+        }
+
+        // If we got an error other than NoSuchKey, the extract failed.
+        else if (rpExtractStatus != ErrorCodes::NoSuchKey) {
+            return rpExtractStatus;
+        }
+
+        return Status::OK();
+    }
+
+    /**
+     * Reads a $readPreference from a $queryOptions subobject, if it exists.
+     * Writes out the original command excluding the $queryOptions subobject.
+     */
+    Status extractUnwrappedReadPreference(const BSONObj& unwrappedCommand,
+                                          BSONObjBuilder* commandBob,
+                                          BSONObjBuilder* metadataBob) {
+        BSONElement queryOptionsEl;
+        BSONElement readPrefEl;
+
+        auto queryOptionsExtractStatus = bsonExtractTypedField(unwrappedCommand,
+                                                               kQueryOptionsFieldName,
+                                                               mongo::Object,
+                                                               &queryOptionsEl);
+
+        // If there is no queryOptions subobject, we write out the command and return.
+        if (queryOptionsExtractStatus == ErrorCodes::NoSuchKey) {
+            commandBob->appendElements(unwrappedCommand);
+            return Status::OK();
+        }
+        else if (!queryOptionsExtractStatus.isOK()) {
+            return queryOptionsExtractStatus;
+        }
+
+        // Write out the command excluding the $queryOptions field.
+        for (auto&& elem : unwrappedCommand) {
+            if (elem.fieldNameStringData() != kQueryOptionsFieldName) {
+                commandBob->append(elem);
+            }
+        }
+
+        auto rpExtractStatus = bsonExtractTypedField(queryOptionsEl.embeddedObject(),
+                                                     kReadPreferenceFieldName,
+                                                     mongo::Object,
+                                                     &readPrefEl);
+
+        // If there is a $queryOptions field, we expect there to be a $readPreference.
+        if (!rpExtractStatus.isOK()) {
+            return rpExtractStatus;
+        }
+
+        metadataBob->append(readPrefEl);
+        return Status::OK();
+    }
+
+}  // namespace
+
+    const OperationContext::Decoration<ServerSelectors> ServerSelectors::get =
+        OperationContext::declareDecoration<ServerSelectors>();
+
+    ServerSelectors::ServerSelectors(bool secondaryOk,
+                                     boost::optional<ReadPreferenceSetting> readPreference)
+        : _secondaryOk(secondaryOk)
+        , _readPreference(std::move(readPreference))
+    {}
+
+    StatusWith<ServerSelectors> ServerSelectors::readFromMetadata(const BSONObj& metadata) {
+        auto secondaryOkField = metadata.getField(kSecondaryOkFieldName);
+        auto readPrefField = metadata.getField(kReadPreferenceFieldName);
+
+        bool secondaryOk = !secondaryOkField.eoo();
+
+        boost::optional<ReadPreferenceSetting> readPreference;
+        BSONElement rpElem;
+        auto readPrefExtractStatus = bsonExtractTypedField(metadata,
+                                                           kReadPreferenceFieldName,
+                                                           mongo::Object,
+                                                           &rpElem);
+
+        if (readPrefExtractStatus == ErrorCodes::NoSuchKey) {
+            // Do nothing, it's valid to have no ReadPreference
+        }
+        else if (!readPrefExtractStatus.isOK()) {
+            return readPrefExtractStatus;
+        }
+        else {
+            // We have a read preference in the metadata object.
+            auto parsedRps = ReadPreferenceSetting::fromBSON(rpElem.Obj());
+            if (!parsedRps.isOK()) {
+                return parsedRps.getStatus();
+            }
+            readPreference.emplace(std::move(parsedRps.getValue()));
+        }
+
+        return ServerSelectors(secondaryOk, std::move(readPreference));
+    }
+
+    Status ServerSelectors::writeToMetadata(const ServerSelectors& ss,
+                                            BSONObjBuilder* metadataBob) {
+        if (ss.secondaryOk()) {
+            metadataBob->append(kSecondaryOkFieldName, 1);
+        }
+
+        if (ss.readPreference()) {
+            metadataBob->append(kReadPreferenceFieldName, ss.readPreference()->toBSON());
+        }
+
+        return Status::OK();
+    }
+
+    Status ServerSelectors::downconvert(const BSONObj& command,
+                                        const BSONObj& metadata,
+                                        BSONObjBuilder* legacyCommand,
+                                        int* legacyQueryFlags) {
+
+        BSONElement secondaryOkElem = metadata.getField(kSecondaryOkFieldName);
+        BSONElement readPrefElem = metadata.getField(kReadPreferenceFieldName);
+
+        if (!secondaryOkElem.eoo()) {
+            *legacyQueryFlags |= mongo::QueryOption_SlaveOk;
+        }
+
+        if (!readPrefElem.eoo()) {
+            // Use 'query' to wrap query, then append read preference.
+
+            // NOTE(amidvidy): Oddly, the _isSecondaryQuery implementation in dbclient_rs does
+            // not unwrap the query properly - it only checks for 'query', and not
+            // '$query'. We should probably standardize on one - drivers use '$query',
+            // and the shell uses 'query'. See SERVER-18705 for details.
+
+            // TODO: this may need to use the $queryOptions hack on mongos.
+            legacyCommand->append(kQueryWrapper, command);
+            legacyCommand->append(readPrefElem);
+        } else {
+            legacyCommand->appendElements(command);
+        }
+
+        return Status::OK();
+    }
+
+    Status ServerSelectors::upconvert(const BSONObj& legacyCommand,
+                                      const int legacyQueryFlags,
+                                      BSONObjBuilder* commandBob,
+                                      BSONObjBuilder* metadataBob) {
+
+        // The secondaryOK option is equivalent to the slaveOk bit being set on legacy commands.
+        if (legacyQueryFlags & QueryOption_SlaveOk) {
+            metadataBob->append(kSecondaryOkFieldName, 1);
+        }
+
+        // First we need to check if we have a wrapped command. That is, a command of the form
+        // {'$query': { 'commandName': 1, ...}, '$someOption': 5, ....}. Curiously, the field name
+        // of the wrapped query can be either '$query', or 'query'.
+        BSONObj maybeUnwrapped;
+        bool wasWrapped;
+        std::tie(wasWrapped, maybeUnwrapped) = unwrapCommand(legacyCommand);
+
+        if (wasWrapped) {
+            // Check if legacyCommand has an invalid $maxTimeMS option.
+            // TODO: Move this check elsewhere when handle upconverting/downconverting maxTimeMS.
+            if (legacyCommand.hasField("$maxTimeMS")) {
+                return Status(ErrorCodes::InvalidOptions,
+                              "cannot use $maxTimeMS query option with "
+                              "commands; use maxTimeMS command option "
+                              "instead");
+            }
+
+            // If the command was wrapped, we can write out the upconverted command now, as there
+            // is nothing else we need to remove from it.
+            commandBob->appendElements(maybeUnwrapped);
+
+            return extractWrappedReadPreference(legacyCommand, metadataBob);
+        }
+
+        // If the command was not wrapped, we need to check for a readPreference sent by mongos
+        // on the $queryOptions field of the command. If it is set, we remove it from the
+        // upconverted command, so we need to pass the command builder along.
+        return extractUnwrappedReadPreference(maybeUnwrapped, commandBob, metadataBob);
+    }
+
+    bool ServerSelectors::secondaryOk() const {
+        return _secondaryOk;
+    }
+
+    const boost::optional<ReadPreferenceSetting>& ServerSelectors::readPreference() const {
+        return _readPreference;
+    }
+
+}  // metadata
+}  // rpc
+}  // mongo

--- a/src/mongo/rpc/metadata/server_selectors.h
+++ b/src/mongo/rpc/metadata/server_selectors.h
@@ -1,0 +1,113 @@
+/*
+ *    Copyright (C) 2015 MongoDB Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *    As a special exception, the copyright holders give permission to link the
+ *    code of portions of this program with the OpenSSL library under certain
+ *    conditions as described in each individual source file and distribute
+ *    linked combinations including the program with the OpenSSL library. You
+ *    must comply with the GNU Affero General Public License in all respects for
+ *    all of the code used other than as permitted herein. If you modify file(s)
+ *    with this exception, you may extend this exception to your version of the
+ *    file(s), but you are not obligated to do so. If you do not wish to do so,
+ *    delete this exception statement from your version. If you delete this
+ *    exception statement from all source files in the program, then also delete
+ *    it in the license file.
+ */
+
+#pragma once
+
+#include <boost/optional.hpp>
+
+#include "mongo/base/disallow_copying.h"
+#include "mongo/client/read_preference.h"
+#include "mongo/db/operation_context.h"
+
+namespace mongo {
+    class BSONObj;
+    class BSONObjBuilder;
+    class Status;
+    template <typename T> class StatusWith;
+
+namespace rpc {
+namespace metadata {
+
+    /**
+     * This class comprises the request metadata fields that concern server selection, that is,
+     * the conditions on which servers can execute this operation.
+     */
+    class ServerSelectors {
+        MONGO_DISALLOW_COPYING(ServerSelectors);
+    public:
+        static const OperationContext::Decoration<ServerSelectors> get;
+
+        // TODO: Remove when StatusWith supports default-constructible types (SERVER-18007).
+        ServerSelectors() = default;
+
+        ServerSelectors(ServerSelectors&&) = default;
+
+        ServerSelectors& operator=(ServerSelectors&&) = default;
+
+        /**
+         * Loads ServerSelectors from a metadata object, and stores it on this OperationContext.
+         */
+        static StatusWith<ServerSelectors> readFromMetadata(const BSONObj& metadataObj);
+
+        /**
+         * Writes this operation's ServerSelectors to a metadata object.
+         */
+        static Status writeToMetadata(const ServerSelectors& ss, BSONObjBuilder* metadataBob);
+
+        /**
+         * Rewrites the ServerSelectors from the legacy OP_QUERY format to the metadata
+         * object format. In particular, if secondaryOk is set, this will set QueryOption_SlaveOk
+         * on the legacyQueryFlags. If a readPreference is set, the legacy command will be wrapped
+         * in a $query element (if it is not already), and a top-level $readPreference field will
+         * be set on the command.
+         */
+        static Status downconvert(const BSONObj& command,
+                                  const BSONObj& metadata,
+                                  BSONObjBuilder* legacyQueryBob,
+                                  int* legacyQueryFlags);
+
+        /**
+         * Rewrites the ServerSelectors from the legacy OP_QUERY format to the metadata
+         * object format.
+         */
+        static Status upconvert(const BSONObj& legacyCommand,
+                                const int legacyQueryFlags,
+                                BSONObjBuilder* commandBob,
+                                BSONObjBuilder* metadataBob);
+        /**
+         * Returns true if this operation has been explicitly overridden to run on a secondary.
+         * This replaces previous usage of QueryOption_SlaveOk.
+         */
+        bool secondaryOk() const;
+
+        /**
+         * Returns the ReadPreference associated with this operation. See
+         * mongo/client/read_preference.h for further details.
+         */
+        const boost::optional<ReadPreferenceSetting>& readPreference() const;
+
+    private:
+        ServerSelectors(bool secondaryOk, boost::optional<ReadPreferenceSetting> readPreference);
+
+        bool _secondaryOk{false};
+        boost::optional<ReadPreferenceSetting> _readPreference{};
+    };
+
+}  // namespace metadata
+}  // namespace rpc
+}  // namespace mongo

--- a/src/mongo/rpc/metadata/server_selectors_test.cpp
+++ b/src/mongo/rpc/metadata/server_selectors_test.cpp
@@ -1,0 +1,168 @@
+/*
+ *    Copyright (C) 2015 MongoDB Inc.
+ *
+ *    This program is free software: you can redistribute it and/or  modify
+ *    it under the terms of the GNU Affero General Public License, version 3,
+ *    as published by the Free Software Foundation.
+ *
+ *    This program is distributed in the hope that it will be useful,
+ *    but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *    GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *    As a special exception, the copyright holders give permission to link the
+ *    code of portions of this program with the OpenSSL library under certain
+ *    conditions as described in each individual source file and distribute
+ *    linked combinations including the program with the OpenSSL library. You
+ *    must comply with the GNU Affero General Public License in all respects for
+ *    all of the code used other than as permitted herein. If you modify file(s)
+ *    with this exception, you may extend this exception to your version of the
+ *    file(s), but you are not obligated to do so. If you do not wish to do so,
+ *    delete this exception statement from your version. If you delete this
+ *    exception statement from all source files in the program, then also delete
+ *    it in the license file.
+ */
+
+#include "mongo/platform/basic.h"
+
+#include "mongo/client/dbclientinterface.h"
+#include "mongo/client/read_preference.h"
+#include "mongo/db/jsobj.h"
+#include "mongo/rpc/metadata/server_selectors.h"
+#include "mongo/unittest/unittest.h"
+
+namespace {
+    using namespace mongo;
+    using namespace mongo::rpc::metadata;
+    using mongo::unittest::assertGet;
+
+    ServerSelectors checkParse(const BSONObj& metadata) {
+        auto swSs = ServerSelectors::readFromMetadata(metadata);
+        ASSERT_TRUE(swSs.isOK());
+        return swSs.getValue();
+    }
+
+
+    TEST(ServerSelectors, ReadFromMetadata) {
+        {
+            // Empty object - should work just fine.
+            auto ss = checkParse(BSONObj());
+            ASSERT_FALSE(ss.secondaryOk());
+            ASSERT_FALSE(ss.readPreference().is_initialized());
+        }
+        {
+            // Set secondaryOk but not readPreference.
+            auto ss = checkParse(BSON("$secondaryOk" << 1));
+            ASSERT_TRUE(ss.secondaryOk());
+            ASSERT_FALSE(ss.readPreference().is_initialized());
+        }
+        {
+            // Set readPreference but not secondaryOk.
+            auto ss = checkParse(BSON("$readPreference" <<
+                                     BSON("mode" << "primary")));
+            ASSERT_FALSE(ss.secondaryOk());
+            ASSERT_TRUE(ss.readPreference().is_initialized());
+            ASSERT_TRUE(ss.readPreference()->pref == ReadPreference::PrimaryOnly);
+        }
+        {
+            // Set both.
+            auto ss = checkParse(BSON("$secondaryOk" << 1 <<
+                                      "$readPreference" <<
+                                     BSON("mode" << "secondaryPreferred")));
+            ASSERT_TRUE(ss.secondaryOk());
+            ASSERT_TRUE(ss.readPreference()->pref == ReadPreference::SecondaryPreferred);
+        }
+    }
+
+    void checkUpconvert(const BSONObj& legacyCommand,
+                        const int legacyQueryFlags,
+                        const BSONObj& upconvertedCommand,
+                        const BSONObj& upconvertedMetadata) {
+        BSONObjBuilder upconvertedCommandBob;
+        BSONObjBuilder upconvertedMetadataBob;
+        auto convertStatus = ServerSelectors::upconvert(legacyCommand,
+                                                        legacyQueryFlags,
+                                                        &upconvertedCommandBob,
+                                                        &upconvertedMetadataBob);
+        ASSERT_OK(convertStatus);
+        // We don't care about the order of the fields in the metadata object
+        const auto sorted = [](const BSONObj& obj) {
+            BSONObjIteratorSorted iter(obj);
+            BSONObjBuilder bob;
+            while (iter.more()) {
+                bob.append(iter.next());
+            }
+            return bob.obj();
+        };
+
+        ASSERT_EQ(upconvertedCommand,  upconvertedCommandBob.done());
+        ASSERT_EQ(sorted(upconvertedMetadata), sorted(upconvertedMetadataBob.done()));
+    }
+
+    TEST(ServerSelectors, UpconvertValidMetadata) {
+        // Wrapped in $query, with readPref and slaveOk bit set.
+        checkUpconvert(BSON("$query" << BSON("ping" << 1) <<
+                            "$readPreference" << BSON("mode" << "secondary")),
+                       mongo::QueryOption_SlaveOk,
+                       BSON("ping" << 1),
+                       BSON("$secondaryOk" << 1 <<
+                            "$readPreference" << BSON("mode" << "secondary")));
+
+        // Wrapped in 'query', with readPref.
+        checkUpconvert(BSON("query" << BSON("pong" << 1 << "foo" << "bar") <<
+                            "$readPreference" << BSON("mode" << "primary" <<
+                                                      "tags" << BSON("dc" << "ny"))),
+                       0,
+                       BSON("pong" << 1 << "foo" << "bar"),
+                       BSON("$readPreference" << BSON("mode" << "primary" <<
+                                                      "tags" << BSON("dc" << "ny"))));
+        // Unwrapped, no readPref, no slaveOk
+        checkUpconvert(BSON("ping" << 1),
+                       0,
+                       BSON("ping" << 1),
+                       BSONObj());
+
+        // Readpref wrapped in $queryOptions
+        checkUpconvert(BSON("pang" << "pong" <<
+                            "$queryOptions" <<
+                            BSON("$readPreference" << BSON("mode" << "nearest" <<
+                                                           "tags" << BSON("rack" << "city")))),
+                       0,
+                       BSON("pang" << "pong"),
+                       BSON("$readPreference" << BSON("mode" << "nearest" <<
+                                                      "tags" << BSON("rack" << "city"))));
+    }
+
+    void checkUpconvertFails(const BSONObj& legacyCommand) {
+        BSONObjBuilder upconvertedCommandBob;
+        BSONObjBuilder upconvertedMetadataBob;
+        ASSERT_NOT_OK(ServerSelectors::upconvert(legacyCommand,
+                                                 0,
+                                                 &upconvertedCommandBob,
+                                                 &upconvertedMetadataBob));
+    }
+
+    TEST(ServerSelectors, UpconvertInvalidMetadata) {
+        // $readPreference not an object.
+        checkUpconvertFails(BSON("$query" << BSON("pang" << "pong") <<
+                                 "$readPreference" << 2));
+
+        // has $maxTimeMS option
+        checkUpconvertFails(BSON("query" << BSON("foo" << "bar") <<
+                                 "$maxTimeMS" << 200));
+        checkUpconvertFails(BSON("$query" << BSON("foo" << "bar") <<
+                                 "$maxTimeMS" << 200));
+
+        // has $queryOptions field, but invalid $readPreference
+        checkUpconvertFails(BSON("ping" << "pong" <<
+                                 "$queryOptions" << BSON("$readPreference" << 1.2)));
+
+        // has $queryOptions field, but no $readPreference
+        checkUpconvertFails(BSON("ping" << "pong" <<
+                                 "$queryOptions" << BSONObj()));
+    }
+
+}

--- a/src/mongo/s/s_only.cpp
+++ b/src/mongo/s/s_only.cpp
@@ -68,18 +68,17 @@ namespace mongo {
     // to their old style equivalents.
     void Command::execCommand(OperationContext* txn,
                               Command* command,
-                              const BSONObj& interposedCmd,
                               const rpc::RequestInterface& request,
                               rpc::ReplyBuilderInterface* replyBuilder) {
 
         int queryFlags = 0;
+        BSONObj cmdObj;
 
-        std::tie(std::ignore, queryFlags) = uassertStatusOK(
+        std::tie(cmdObj, queryFlags) = uassertStatusOK(
             rpc::metadata::downconvertRequest(request.getCommandArgs(),
                                               request.getMetadata())
         );
 
-        BSONObj cmdObj = interposedCmd;
         std::string db = request.getDatabase().rawData();
         BSONObjBuilder result;
 


### PR DESCRIPTION
- secondaryOk is upconverted/downconverted from QueryOption_SlaveOk
- readPreference is upconverted/downconverted from $query wrapped
  commands or $queryOptions
- both are now accessed via OperationContext instead of being read from
  a mutable command object
- removed logic for parsing secondaryOk and readPreference from the
  command execution pipeline in dbcommands.cpp
